### PR TITLE
Add AB Test Types

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,8 @@
 # ab-tests
+
 Client-side ab testing framework (broken out from Frontend)
+
+## TODO
+
+-   bundling https://www.npmjs.com/package/microbundle ✅
+-   Generate flow types from Typescript definition https://github.com/joarwilk/flowgen

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
 		"test": "jest",
 		"tsc": "tsc",
 		"lint": "eslint . --ext .ts",
-		"createTsDec": "tsc --emitDeclarationOnly true --declaration true --declarationDir build/ --noEmit false",
 		"build": "microbundle",
 		"dev": "microbundle watch"
 	},

--- a/src/types.ts
+++ b/src/types.ts
@@ -23,6 +23,20 @@ export interface EngagementBannerTemplateParams {
 	secondaryLinkLabel?: string;
 	subsLinkUrl?: string;
 }
+
+/**
+ * AllExistingSupporters - all recurring, all one-offs in last 3 months
+ * AllNonSupporters - no recurring, no one-offs in last 3 months
+ * Everyone
+ * PostAskPauseSingleContributors - people who made a contribution more than 3 months ago
+ *
+ * Note - PostAskPauseSingleContributors is a subset of AllNonSupporters, so priority ordering of these tests is important
+ */
+export type AcquisitionsComponentUserCohort =
+	| 'AllExistingSupporters'
+	| 'AllNonSupporters'
+	| 'Everyone'
+	| 'PostAskPauseSingleContributors';
 export interface EngagementBannerTestParams {
 	titles?: string[];
 	leadSentence?: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,71 @@
+export type OphanProduct =
+	| 'CONTRIBUTION'
+	| 'RECURRING_CONTRIBUTION'
+	| 'MEMBERSHIP_SUPPORTER'
+	| 'MEMBERSHIP_PATRON'
+	| 'MEMBERSHIP_PARTNER'
+	| 'DIGITAL_SUBSCRIPTION'
+	| 'PRINT_SUBSCRIPTION';
+
+export interface EngagementBannerTemplateParams {
+	titles?: Array<string>;
+	leadSentence?: string;
+	closingSentence?: string;
+	messageText: string;
+	mobileMessageText?: string;
+	ctaText: string;
+	buttonCaption: string;
+	linkUrl: string;
+	hasTicker: boolean;
+	tickerHeader?: string;
+	signInUrl?: string;
+	secondaryLinkUrl?: string;
+	secondaryLinkLabel?: string;
+	subsLinkUrl?: string;
+}
+export interface EngagementBannerTestParams {
+	titles?: Array<string>;
+	leadSentence?: string;
+	messageText?: string;
+	ctaText?: string;
+	buttonCaption?: string;
+	linkUrl?: string;
+	hasTicker?: boolean;
+	tickerHeader?: string;
+	products?: OphanProduct[];
+	template?: (templateParams: EngagementBannerTemplateParams) => string;
+	bannerModifierClass?: string;
+	minArticlesBeforeShowingBanner?: number;
+	userCohort?: AcquisitionsComponentUserCohort;
+	bannerShownCallback?: () => void;
+}
+
+type ListenerFunction = (f: () => void) => void;
+
+export interface Variant {
+	id: string;
+	test: (x: Object) => void;
+	campaignCode?: string;
+	canRun?: () => boolean;
+	impression?: ListenerFunction;
+	success?: ListenerFunction;
+	engagementBannerParams?: EngagementBannerTestParams;
+}
+
 export interface AbTest {
-	name: string;
+	id: string;
+	start: string;
+	expiry: string;
+	author: string;
+	description: string;
+	audience: number;
+	audienceOffset: number;
+	successMeasure: string;
+	audienceCriteria: string;
+	showForSensitive?: boolean;
+	idealOutcome?: string;
+	dataLinkNames?: string;
+	variants: ReadonlyArray<Variant>;
+	canRun: () => boolean;
+	notInTest?: () => void;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,7 +8,7 @@ export type OphanProduct =
 	| 'PRINT_SUBSCRIPTION';
 
 export interface EngagementBannerTemplateParams {
-	titles?: Array<string>;
+	titles?: string[];
 	leadSentence?: string;
 	closingSentence?: string;
 	messageText: string;
@@ -24,7 +24,7 @@ export interface EngagementBannerTemplateParams {
 	subsLinkUrl?: string;
 }
 export interface EngagementBannerTestParams {
-	titles?: Array<string>;
+	titles?: string[];
 	leadSentence?: string;
 	messageText?: string;
 	ctaText?: string;
@@ -44,7 +44,7 @@ type ListenerFunction = (f: () => void) => void;
 
 export interface Variant {
 	id: string;
-	test: (x: Object) => void;
+	test: (x: Record<string, unknown>) => void;
 	campaignCode?: string;
 	canRun?: () => boolean;
 	impression?: ListenerFunction;


### PR DESCRIPTION
Copied over from Frontend, the types as close as possible with mods (changed `Object` to `Record<string, unknown>`).

We may be able to automatically generate these flow types for Frontend.