### PR TITLE
Single export

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ type initABCoreConfig = {
 // forcedTestVariant: In Frontend this might be set by the URL override, but otherwise can be used to force a user into a test and variant at init time
 // forcedTestException: Can be used to force a user out of a test (in Frontend, again with url override)
 
-export const initABCore = (config: initABCoreConfig): abCoreAPI
+export const initABCore = (config: initABCoreConfig): coreAPI
 ```
 
 `initAbCore(...)` returns the core API.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,55 @@
 
 Client-side ab testing framework (broken out from Frontend)
 
+## API
+
+### AB Test Core
+
+Initalise the AB Test framework with `initAbCore()`
+
+```ts
+type initABCoreConfig = {
+    mvtMaxValue: number;
+    mvtCookieId: number;
+    pageIsSensitive: boolean;
+    abTestSwitches: Record<string, boolean>;
+    forcedTestVariant?: { testId: ABTest['id']; variant: Variant };
+    forcedTestException?: ABTest['id'];
+};
+
+// mvtMaxValue: MVT % is calculated from 0 to mvtMaxValue
+// mvtCookieId: The user's MVT ID to calculate what tests and variants they fall into
+// pageIsSensitive: In Frontend set by page.config.isSensitive
+// abTestSwitches: An object containing all of the boolean values of abTestSwitches, in Frontend from page.config.switches.abTests
+// forcedTestVariant: In Frontend this might be set by the URL override, but otherwise can be used to force a user into a test and variant at init time
+// forcedTestException: Can be used to force a user out of a test (in Frontend, again with url override)
+
+export const initABCore = (config: initABCoreConfig): abCoreAPI
+```
+
+`initAbCore(...)` returns the core API.
+
+```ts
+// Pass the configuration from the platform that the AB tests rely on
+const initABCoreDefaultConfig = {
+	mvtMaxValue: 1000000,
+	mvtCookieId: 1234,
+	pageIsSensitive: false,
+	abTestSwitches: {
+		DummyTest: true,
+	},
+};
+
+const abTestLibDefault = initABCore(initABCoreDefaultConfig);
+
+// Provides access to
+abTestLibDefault.runnableTest();
+abTestLibDefault.allRunnableTests();
+abTestLibDefault.firstRunnableTest();
+```
+
 ## TODO
 
 -   bundling https://www.npmjs.com/package/microbundle ✅
 -   Generate flow types from Typescript definition https://github.com/joarwilk/flowgen
+-   Move time-utils to a packaged lib folder

--- a/README.md
+++ b/README.md
@@ -1,2 +1,8 @@
 # ab-tests
+
 Client-side ab testing framework (broken out from Frontend)
+
+## TODO
+
+-   bundling https://www.npmjs.com/package/microbundle ✅
+-   Generate flow types from Typescript definition https://github.com/joarwilk/flowgen

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "ab-tests",
-	"version": "1.0.0",
+	"version": "0.0.1",
 	"repository": "https://github.com/guardian/ab-tests.git",
 	"author": "The Guardian",
 	"license": "Apache-2.0",
@@ -18,6 +18,7 @@
 		"tsc": "tsc",
 		"lint": "eslint . --ext .ts",
 		"build": "microbundle",
+		"validate": "yarn lint && yarn tsc && yarn test",
 		"dev": "microbundle watch"
 	},
 	"devDependencies": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
 		"test": "jest",
 		"tsc": "tsc",
 		"lint": "eslint . --ext .ts",
-		"createTsDec": "tsc --emitDeclarationOnly true --declaration true --declarationDir build/ --noEmit false",
 		"build": "microbundle",
 		"dev": "microbundle watch"
 	},

--- a/src/ab-core.test.ts
+++ b/src/ab-core.test.ts
@@ -1,0 +1,159 @@
+import { genAbTest, genVariant } from './fixtures/ab-test';
+import { initABCore } from './ab-core';
+
+const initABCoreDefaultConfig = {
+	mvtMaxValue: 1000000,
+	mvtCookieId: 1234,
+	pageIsSensitive: false,
+	abTestSwitches: {
+		DummyTest: true,
+		DummyTestException: true,
+	},
+};
+
+const abTestLibDefault = initABCore(initABCoreDefaultConfig);
+
+describe('A/B tests', () => {
+	beforeEach(() => {
+		window.location.hash = '';
+	});
+
+	describe('runnableTest', () => {
+		test('should return null for an expired test', () => {
+			const expiredTest = genAbTest('DummyTest', true, '2000-01-01');
+			expect(abTestLibDefault.runnableTest(expiredTest)).toEqual(null);
+		});
+
+		test('should return null for a test which is switched off', () => {
+			const test = genAbTest('DummyTest');
+			const rt = abTestLibDefault.runnableTest(test);
+			expect(rt).toBeNull();
+		});
+
+		test('should return null if the test cannot be run', () => {
+			const test = genAbTest('DummyTest', false);
+			expect(abTestLibDefault.runnableTest(test)).toBeNull();
+		});
+
+		test('should return null if the test can be run but the variant cannot', () => {
+			const test = genAbTest('DummyTest', true, '9999-12-12', [
+				genVariant('control', false),
+			]);
+			expect(abTestLibDefault.runnableTest(test)).toBeNull();
+		});
+
+		test('should return null if the mvtId is not in the audience offset', () => {
+			const test = genAbTest(
+				'DummyTest',
+				true,
+				undefined,
+				undefined,
+				undefined,
+				0.5,
+			);
+			expect(abTestLibDefault.runnableTest(test)).toBeNull();
+		});
+
+		test('should return true if the mvtId is in the audience offset', () => {
+			const abTestLib = initABCore({
+				...initABCoreDefaultConfig,
+				...{
+					mvtCookieId: 600000,
+				},
+			});
+			const test = genAbTest(
+				'DummyTest',
+				true,
+				undefined,
+				undefined,
+				undefined,
+				0.5,
+			);
+			expect(abTestLib.runnableTest(test)).not.toBeNull();
+		});
+
+		test('should return the forced variant on matching test', () => {
+			const abTestLib = initABCore({
+				...initABCoreDefaultConfig,
+				...{
+					forcedTestVariant: {
+						testId: 'DummyTest',
+						variant: genVariant('variant123', true),
+					},
+				},
+			});
+			const test = genAbTest('DummyTest', true);
+			const rt = abTestLib.runnableTest(test);
+			expect(rt).not.toBeNull();
+			if (rt) {
+				expect(rt.variantToRun).toHaveProperty('id', 'variant123');
+			}
+		});
+
+		test('should return the variantToRun specified by the cookie, if the test is not the runnableTest param', () => {
+			const abTestLib = initABCore({
+				...initABCoreDefaultConfig,
+				...{
+					forcedTestVariant: {
+						testId: 'NotDummyTest',
+						variant: genVariant('variant123', true),
+					},
+				},
+			});
+			const test = genAbTest('DummyTest', true, undefined, [
+				genVariant('control234', true),
+				genVariant('variant234', true),
+			]);
+			const rt = abTestLib.runnableTest(test);
+			expect(rt).not.toBeNull();
+			if (rt) {
+				expect(rt.variantToRun).toHaveProperty('id', 'control234');
+			}
+		});
+
+		test('should return the variantToRun specified by the cookie, if forced variant is absent (odd cookie)', () => {
+			const test = genAbTest('DummyTest', true, undefined, [
+				genVariant('control234', true),
+				genVariant('variant234', true),
+			]);
+			const rt = abTestLibDefault.runnableTest(test);
+			expect(rt).not.toBeNull();
+			if (rt) {
+				expect(rt.variantToRun).toHaveProperty('id', 'control234');
+			}
+		});
+
+		test('should return the variantToRun specified by the cookie, if forced variant is absent (even cookie)', () => {
+			const abTestLib = initABCore({
+				...initABCoreDefaultConfig,
+				...{
+					mvtCookieId: 1245,
+				},
+			});
+			const test = genAbTest('DummyTest', true, undefined, [
+				genVariant('control234', true),
+				genVariant('variant234', true),
+			]);
+			const rt = abTestLib.runnableTest(test);
+			expect(rt).not.toBeNull();
+			if (rt) {
+				expect(rt.variantToRun).toHaveProperty('id', 'variant234');
+			}
+		});
+
+		test('when forcedTestException is set, it should return null for matching tests and not null for other tests', () => {
+			const abTestLib = initABCore({
+				...initABCoreDefaultConfig,
+				...{ forcedTestException: 'DummyTestException' },
+			});
+
+			const test = genAbTest('DummyTest', true);
+			const rt = abTestLib.runnableTest(test);
+			expect(rt).not.toBeNull();
+
+			const testException = genAbTest('DummyTestException');
+			const rtException = abTestLib.runnableTest(testException);
+			expect(rtException).toBeNull();
+		});
+	});
+});

--- a/src/ab-core.test.ts
+++ b/src/ab-core.test.ts
@@ -1,7 +1,7 @@
 import { genAbTest, genVariant } from './fixtures/ab-test';
-import { initABCore } from './ab-core';
+import { initCore } from './ab-core';
 
-const initABCoreDefaultConfig = {
+const initCoreDefaultConfig = {
 	mvtMaxValue: 1000000,
 	mvtCookieId: 1234,
 	pageIsSensitive: false,
@@ -11,7 +11,7 @@ const initABCoreDefaultConfig = {
 	},
 };
 
-const abTestLibDefault = initABCore(initABCoreDefaultConfig);
+const abTestLibDefault = initCore(initCoreDefaultConfig);
 
 describe('A/B tests', () => {
 	beforeEach(() => {
@@ -55,8 +55,8 @@ describe('A/B tests', () => {
 		});
 
 		test('should return true if the mvtId is in the audience offset', () => {
-			const abTestLib = initABCore({
-				...initABCoreDefaultConfig,
+			const abTestLib = initCore({
+				...initCoreDefaultConfig,
 				...{
 					mvtCookieId: 600000,
 				},
@@ -73,8 +73,8 @@ describe('A/B tests', () => {
 		});
 
 		test('should return the forced variant on matching test', () => {
-			const abTestLib = initABCore({
-				...initABCoreDefaultConfig,
+			const abTestLib = initCore({
+				...initCoreDefaultConfig,
 				...{
 					forcedTestVariant: {
 						testId: 'DummyTest',
@@ -91,8 +91,8 @@ describe('A/B tests', () => {
 		});
 
 		test('should return the variantToRun specified by the cookie, if the test is not the runnableTest param', () => {
-			const abTestLib = initABCore({
-				...initABCoreDefaultConfig,
+			const abTestLib = initCore({
+				...initCoreDefaultConfig,
 				...{
 					forcedTestVariant: {
 						testId: 'NotDummyTest',
@@ -124,8 +124,8 @@ describe('A/B tests', () => {
 		});
 
 		test('should return the variantToRun specified by the cookie, if forced variant is absent (even cookie)', () => {
-			const abTestLib = initABCore({
-				...initABCoreDefaultConfig,
+			const abTestLib = initCore({
+				...initCoreDefaultConfig,
 				...{
 					mvtCookieId: 1245,
 				},
@@ -142,8 +142,8 @@ describe('A/B tests', () => {
 		});
 
 		test('when forcedTestException is set, it should return null for matching tests and not null for other tests', () => {
-			const abTestLib = initABCore({
-				...initABCoreDefaultConfig,
+			const abTestLib = initCore({
+				...initCoreDefaultConfig,
 				...{ forcedTestException: 'DummyTestException' },
 			});
 

--- a/src/ab-core.ts
+++ b/src/ab-core.ts
@@ -1,26 +1,8 @@
-import { ABTest, Variant, Runnable } from './types';
+import { ABTest, Variant, Runnable, ConfigType, coreAPI } from './types';
 // import { getVariantFromLocalStorage } from './ab-local-storage'; // Deprecating from localstorage
 import { isExpired } from './lib/time-utils';
 
-type abCoreAPI = {
-	runnableTest: (test: ABTest) => Runnable<ABTest> | null;
-	allRunnableTests: (
-		tests: ReadonlyArray<ABTest>,
-	) => ReadonlyArray<Runnable<ABTest>> | [];
-	firstRunnableTest: (
-		tests: ReadonlyArray<ABTest>,
-	) => Runnable<ABTest> | null;
-};
-
-type initABCoreConfig = {
-	mvtMaxValue: number;
-	mvtCookieId: number;
-	pageIsSensitive: boolean;
-	abTestSwitches: Record<string, boolean>;
-	forcedTestVariant?: { testId: ABTest['id']; variant: Variant };
-	forcedTestException?: ABTest['id'];
-};
-export const initABCore = (config: initABCoreConfig): abCoreAPI => {
+export const initCore = (config: ConfigType): coreAPI => {
 	const {
 		mvtMaxValue,
 		mvtCookieId,
@@ -82,7 +64,7 @@ export const initABCore = (config: initABCoreConfig): abCoreAPI => {
 	// actually has a variant which could run on this pageview.
 	//
 	// This function can be called at any time, it should always give the same result for a given pageview.
-	const runnableTest: abCoreAPI['runnableTest'] = (test) => {
+	const runnableTest: coreAPI['runnableTest'] = (test) => {
 		// const fromLocalStorage = getVariantFromLocalStorage(test); // We're deprecating accessing localstorage
 		const fromCookie = computeVariantFromMvtCookie(test);
 		const fromForcedTest =
@@ -111,7 +93,7 @@ export const initABCore = (config: initABCoreConfig): abCoreAPI => {
 	};
 
 	// please ignore
-	const allRunnableTests: abCoreAPI['allRunnableTests'] = (tests) =>
+	const allRunnableTests: coreAPI['allRunnableTests'] = (tests) =>
 		tests.reduce<Runnable<ABTest>[]>((prev, currentValue) => {
 			// in this pr
 			const rt = runnableTest(currentValue); // i will remove these comments
@@ -119,7 +101,7 @@ export const initABCore = (config: initABCoreConfig): abCoreAPI => {
 		}, []); // ta
 
 	// Please ignore
-	const firstRunnableTest: abCoreAPI['firstRunnableTest'] = (tests) =>
+	const firstRunnableTest: coreAPI['firstRunnableTest'] = (tests) =>
 		tests // in this pr
 			.map((test: ABTest) => runnableTest(test)) // I will remove these comments
 			.find((rt: Runnable<ABTest> | null) => rt !== null) || null; // so that this API can be reviewed seperate

--- a/src/ab-core.ts
+++ b/src/ab-core.ts
@@ -1,0 +1,132 @@
+import { ABTest, Variant, Runnable } from './types';
+// import { getVariantFromLocalStorage } from './ab-local-storage'; // Deprecating from localstorage
+import { isExpired } from './lib/time-utils';
+
+type abCoreAPI = {
+	runnableTest: (test: ABTest) => Runnable<ABTest> | null;
+	allRunnableTests: (
+		tests: ReadonlyArray<ABTest>,
+	) => ReadonlyArray<Runnable<ABTest>> | [];
+	firstRunnableTest: (
+		tests: ReadonlyArray<ABTest>,
+	) => Runnable<ABTest> | null;
+};
+
+type initABCoreConfig = {
+	mvtMaxValue: number;
+	mvtCookieId: number;
+	pageIsSensitive: boolean;
+	abTestSwitches: Record<string, boolean>;
+	forcedTestVariant?: { testId: ABTest['id']; variant: Variant };
+	forcedTestException?: ABTest['id'];
+};
+export const initABCore = (config: initABCoreConfig): abCoreAPI => {
+	const {
+		mvtMaxValue,
+		mvtCookieId,
+		pageIsSensitive,
+		abTestSwitches,
+		forcedTestVariant,
+		forcedTestException,
+	} = config;
+	// We only take account of a variant's canRun function if it's defined.
+	// If it's not, assume the variant can be run.
+	const variantCanBeRun = (variant: Variant): boolean =>
+		!(variant.canRun && !variant.canRun()) && variant.id !== 'notintest';
+
+	const testCanBeRun = (test: ABTest): boolean => {
+		const expired = isExpired(test.expiry);
+		const isSensitive = pageIsSensitive;
+		const shouldShowForSensitive = !!test.showForSensitive;
+		const isTestOn = abTestSwitches[test.id] && !!abTestSwitches[test.id];
+		const canTestBeRun = !test.canRun || test.canRun();
+
+		// console.log('expired', expired);
+		// console.log('isSensitive', isSensitive);
+		// console.log('shouldShowForSensitive', shouldShowForSensitive);
+		// console.log('isTestOn', isTestOn);
+		// console.log('canTestBeRun', canTestBeRun);
+		// console.log('test.canRun()', test.canRun());
+
+		return (
+			(isSensitive ? shouldShowForSensitive : true) &&
+			isTestOn &&
+			!expired &&
+			canTestBeRun
+		);
+	};
+
+	// Determine whether the user is in the test or not and return the associated
+	// variant ID, based on the MVT cookie segmentation.
+	//
+	// The test population is just a subset of MVT ids. A test population must
+	// begin from a specific value. Overlapping test ranges are permitted.
+	const computeVariantFromMvtCookie = (test: ABTest): Variant | null => {
+		const smallestTestId = mvtMaxValue * test.audienceOffset;
+		const largestTestId = smallestTestId + mvtMaxValue * test.audience;
+
+		if (
+			mvtCookieId &&
+			mvtCookieId > smallestTestId &&
+			mvtCookieId <= largestTestId
+		) {
+			// This mvt test id is in the test range, so allocate it to a test variant.
+			return test.variants[mvtCookieId % test.variants.length];
+		}
+
+		return null;
+	};
+
+	// This is the heart of the A/B testing framework.
+	// It turns an ABTest into a Runnable<ABTest>, if indeed the test
+	// actually has a variant which could run on this pageview.
+	//
+	// This function can be called at any time, it should always give the same result for a given pageview.
+	const runnableTest: abCoreAPI['runnableTest'] = (test) => {
+		// const fromLocalStorage = getVariantFromLocalStorage(test); // We're deprecating accessing localstorage
+		const fromCookie = computeVariantFromMvtCookie(test);
+		const fromForcedTest =
+			forcedTestVariant?.testId === test.id && forcedTestVariant.variant;
+		const forcedOutOfTest = forcedTestException === test.id;
+		const variantToRun = fromForcedTest || fromCookie;
+
+		// console.log('ftv', forcedTestVariant);
+		// console.log('fft', fromForcedTest);
+		// console.log('vtr', variantToRun);
+		// console.log('tcbr', testCanBeRun(test));
+
+		if (
+			!forcedOutOfTest &&
+			testCanBeRun(test) &&
+			variantToRun &&
+			variantCanBeRun(variantToRun)
+		) {
+			return {
+				...test,
+				variantToRun,
+			};
+		}
+
+		return null;
+	};
+
+	// please ignore
+	const allRunnableTests: abCoreAPI['allRunnableTests'] = (tests) =>
+		tests.reduce<Runnable<ABTest>[]>((prev, currentValue) => {
+			// in this pr
+			const rt = runnableTest(currentValue); // i will remove these comments
+			return rt ? [...prev, rt] : prev; // so that this api can be reviewed seperate
+		}, []); // ta
+
+	// Please ignore
+	const firstRunnableTest: abCoreAPI['firstRunnableTest'] = (tests) =>
+		tests // in this pr
+			.map((test: ABTest) => runnableTest(test)) // I will remove these comments
+			.find((rt: Runnable<ABTest> | null) => rt !== null) || null; // so that this API can be reviewed seperate
+
+	return {
+		runnableTest,
+		allRunnableTests,
+		firstRunnableTest,
+	};
+};

--- a/src/ab.test.ts
+++ b/src/ab.test.ts
@@ -1,7 +1,0 @@
-import { ab } from './ab';
-
-describe('AB entry', () => {
-	it('Should work', () => {
-		expect(ab()).toEqual('it works');
-	});
-});

--- a/src/ab.ts
+++ b/src/ab.ts
@@ -1,1 +1,0 @@
-export const ab = (): string => 'it works';

--- a/src/example.test.ts
+++ b/src/example.test.ts
@@ -1,0 +1,19 @@
+import { initExample } from './example';
+
+const config = {
+	mvtMaxValue: 1000000,
+	mvtCookieId: 1234,
+	pageIsSensitive: false,
+	abTestSwitches: {
+		DummyTest: true,
+		DummyTestException: true,
+	},
+	deleteme: true,
+};
+
+describe('example', () => {
+	const example = initExample(config);
+	it('should want to be deleted', () => {
+		expect(example.deleteme).toBe(true);
+	});
+});

--- a/src/example.ts
+++ b/src/example.ts
@@ -1,0 +1,7 @@
+import { exampleAPI, ConfigType } from './types';
+
+export const initExample = (config: ConfigType): exampleAPI => {
+	return {
+		deleteme: config.deleteme || false,
+	};
+};

--- a/src/fixtures/ab-test.ts
+++ b/src/fixtures/ab-test.ts
@@ -1,0 +1,53 @@
+import { Runnable, ABTest, Variant } from '../types';
+
+export const genVariant = (id: string, canRun?: boolean): Variant => ({
+	id,
+	test: (): undefined => undefined,
+	...(canRun != null ? { canRun: (): boolean => !!canRun } : {}),
+});
+
+export const genAbTest = (
+	id: string,
+	canRun?: boolean,
+	expiry?: string,
+	variants?: Variant[],
+	audience?: number,
+	audienceOffset?: number,
+): ABTest => ({
+	id,
+	audienceCriteria: 'n/a',
+	audienceOffset: audienceOffset || 0,
+	audience: audience || 1,
+	author: 'n/a',
+	canRun: (): boolean => {
+		if (canRun !== null) return !!canRun;
+		return true;
+	},
+	description: 'n/a',
+	start: '0001-01-01',
+	expiry: expiry || '9999-12-12',
+	successMeasure: 'n/a',
+	variants: variants || [genVariant('control'), genVariant('variant')],
+});
+
+export const genRunnableAbTestWhereControlIsRunnable = (
+	id: string,
+	canRun?: boolean,
+): Runnable<ABTest> => {
+	const abTest = genAbTest(id, canRun);
+	return {
+		...abTest,
+		variantToRun: abTest.variants[0],
+	};
+};
+
+export const genRunnableAbTestWhereVariantIsRunnable = (
+	id: string,
+	canRun?: boolean,
+): Runnable<ABTest> => {
+	const abTest = genAbTest(id, canRun);
+	return {
+		...abTest,
+		variantToRun: abTest.variants[1],
+	};
+};

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,3 @@
+import { initialise } from './initialise';
+
+export { initialise };

--- a/src/initialise.ts
+++ b/src/initialise.ts
@@ -1,0 +1,13 @@
+import { ConfigType, coreAPI, exampleAPI } from './types';
+
+import { initCore } from './ab-core';
+import { initExample } from './example';
+
+type abAPI = { core: coreAPI; example: exampleAPI };
+
+export const initialise = (config: ConfigType): abAPI => {
+	const core = initCore(config);
+	const example = initExample(config);
+
+	return { core, example };
+};

--- a/src/lib/time-utils.test.ts
+++ b/src/lib/time-utils.test.ts
@@ -1,0 +1,29 @@
+// @flow
+import { isExpired } from './time-utils';
+const startDate = new Date();
+describe('Check if isExpired', () => {
+	it('It should return true if expired', () => {
+		const datePrev = new Date().setDate(startDate.getDate() - 2);
+		const datePrevString = new Date(datePrev).toString();
+
+		expect(isExpired(datePrevString)).toBeTruthy();
+	});
+
+	it('It should return false if not expired', () => {
+		const dateFuture = new Date().setDate(startDate.getDate() + 2);
+		const dateFutureString = new Date(dateFuture).toString();
+
+		expect(isExpired(dateFutureString)).toBeFalsy();
+	});
+
+	it('It should return false if the time is 11am on the day of expiry', () => {
+		const dateToday11am = new Date().setHours(11);
+		const dateToday11amString = new Date(dateToday11am).toString();
+
+		expect(isExpired(dateToday11amString)).toBeFalsy();
+	});
+
+	it('It should return false if the date passed is far future', () => {
+		expect(isExpired('9999-01-01')).toBeFalsy();
+	});
+});

--- a/src/lib/time-utils.ts
+++ b/src/lib/time-utils.ts
@@ -1,0 +1,8 @@
+// Ideally this would be in a npm lib folder
+export const isExpired = (testExpiry: string): boolean => {
+	// new Date(test.expiry) sets the expiry time to 00:00:00
+	// Using SetHours allows a test to run until the END of the expiry day
+	const startOfToday = new Date().setHours(0, 0, 0, 0);
+	const theTestExpiry = new Date(testExpiry).valueOf();
+	return startOfToday > theTestExpiry;
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -37,6 +37,7 @@ export type AcquisitionsComponentUserCohort =
 	| 'AllNonSupporters'
 	| 'Everyone'
 	| 'PostAskPauseSingleContributors';
+
 export interface EngagementBannerTestParams {
 	titles?: string[];
 	leadSentence?: string;
@@ -66,7 +67,7 @@ export interface Variant {
 	engagementBannerParams?: EngagementBannerTestParams;
 }
 
-export interface AbTest {
+export interface ABTest {
 	id: string;
 	start: string;
 	expiry: string;
@@ -83,3 +84,7 @@ export interface AbTest {
 	canRun: () => boolean;
 	notInTest?: () => void;
 }
+
+export type Runnable<ABTest> = ABTest & {
+	variantToRun: Variant;
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,27 @@
+export type exampleAPI = {
+	deleteme: boolean;
+};
+
+export type ConfigType = {
+	mvtMaxValue: number;
+	mvtCookieId: number;
+	pageIsSensitive: boolean;
+	abTestSwitches: Record<string, boolean>;
+	forcedTestVariant?: { testId: ABTest['id']; variant: Variant };
+	forcedTestException?: ABTest['id'];
+	deleteme?: boolean;
+};
+
+export type coreAPI = {
+	runnableTest: (test: ABTest) => Runnable<ABTest> | null;
+	allRunnableTests: (
+		tests: ReadonlyArray<ABTest>,
+	) => ReadonlyArray<Runnable<ABTest>> | [];
+	firstRunnableTest: (
+		tests: ReadonlyArray<ABTest>,
+	) => Runnable<ABTest> | null;
+};
+
 export type OphanProduct =
 	| 'CONTRIBUTION'
 	| 'RECURRING_CONTRIBUTION'

--- a/src/types.ts
+++ b/src/types.ts
@@ -23,6 +23,20 @@ export interface EngagementBannerTemplateParams {
 	secondaryLinkLabel?: string;
 	subsLinkUrl?: string;
 }
+
+/**
+ * AllExistingSupporters - all recurring, all one-offs in last 3 months
+ * AllNonSupporters - no recurring, no one-offs in last 3 months
+ * Everyone
+ * PostAskPauseSingleContributors - people who made a contribution more than 3 months ago
+ *
+ * Note - PostAskPauseSingleContributors is a subset of AllNonSupporters, so priority ordering of these tests is important
+ */
+export type AcquisitionsComponentUserCohort =
+	| 'AllExistingSupporters'
+	| 'AllNonSupporters'
+	| 'Everyone'
+	| 'PostAskPauseSingleContributors';
 export interface EngagementBannerTestParams {
 	titles?: string[];
 	leadSentence?: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,71 @@
+export type OphanProduct =
+	| 'CONTRIBUTION'
+	| 'RECURRING_CONTRIBUTION'
+	| 'MEMBERSHIP_SUPPORTER'
+	| 'MEMBERSHIP_PATRON'
+	| 'MEMBERSHIP_PARTNER'
+	| 'DIGITAL_SUBSCRIPTION'
+	| 'PRINT_SUBSCRIPTION';
+
+export interface EngagementBannerTemplateParams {
+	titles?: Array<string>;
+	leadSentence?: string;
+	closingSentence?: string;
+	messageText: string;
+	mobileMessageText?: string;
+	ctaText: string;
+	buttonCaption: string;
+	linkUrl: string;
+	hasTicker: boolean;
+	tickerHeader?: string;
+	signInUrl?: string;
+	secondaryLinkUrl?: string;
+	secondaryLinkLabel?: string;
+	subsLinkUrl?: string;
+}
+export interface EngagementBannerTestParams {
+	titles?: Array<string>;
+	leadSentence?: string;
+	messageText?: string;
+	ctaText?: string;
+	buttonCaption?: string;
+	linkUrl?: string;
+	hasTicker?: boolean;
+	tickerHeader?: string;
+	products?: OphanProduct[];
+	template?: (templateParams: EngagementBannerTemplateParams) => string;
+	bannerModifierClass?: string;
+	minArticlesBeforeShowingBanner?: number;
+	userCohort?: AcquisitionsComponentUserCohort;
+	bannerShownCallback?: () => void;
+}
+
+type ListenerFunction = (f: () => void) => void;
+
+export interface Variant {
+	id: string;
+	test: (x: Object) => void;
+	campaignCode?: string;
+	canRun?: () => boolean;
+	impression?: ListenerFunction;
+	success?: ListenerFunction;
+	engagementBannerParams?: EngagementBannerTestParams;
+}
+
 export interface AbTest {
-	name: string;
+	id: string;
+	start: string;
+	expiry: string;
+	author: string;
+	description: string;
+	audience: number;
+	audienceOffset: number;
+	successMeasure: string;
+	audienceCriteria: string;
+	showForSensitive?: boolean;
+	idealOutcome?: string;
+	dataLinkNames?: string;
+	variants: ReadonlyArray<Variant>;
+	canRun: () => boolean;
+	notInTest?: () => void;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,7 +8,7 @@ export type OphanProduct =
 	| 'PRINT_SUBSCRIPTION';
 
 export interface EngagementBannerTemplateParams {
-	titles?: Array<string>;
+	titles?: string[];
 	leadSentence?: string;
 	closingSentence?: string;
 	messageText: string;
@@ -24,7 +24,7 @@ export interface EngagementBannerTemplateParams {
 	subsLinkUrl?: string;
 }
 export interface EngagementBannerTestParams {
-	titles?: Array<string>;
+	titles?: string[];
 	leadSentence?: string;
 	messageText?: string;
 	ctaText?: string;
@@ -44,7 +44,7 @@ type ListenerFunction = (f: () => void) => void;
 
 export interface Variant {
 	id: string;
-	test: (x: Object) => void;
+	test: (x: Record<string, unknown>) => void;
 	campaignCode?: string;
 	canRun?: () => boolean;
 	impression?: ListenerFunction;


### PR DESCRIPTION
## What does this change?
Creates the framework to have a single point of access to the ab framework - the function `initialise()`. Calling thjis function returns an object with multiple keys for each logical area of the ab framework, eg:

```
{
  core: { ... },
  orphan: { ... },
  // etc...
}
```

I also renamed a few things to remove some ABness because it seemed to make more sense if these things aren't being exported