### PR TITLE
Add utils

### DIFF
--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -1,0 +1,154 @@
+import { ABTest, Variant, Runnable } from './types';
+
+import {
+	runnableTestsToParticipations,
+	testAndParticipationsToVariant,
+	testExclusionsWhoseSwitchExists,
+} from './utils';
+
+const NOT_IN_TEST = 'notintest';
+
+const genVariant = (id: string, canRun?: boolean): Variant => ({
+	id,
+	test: () => undefined,
+	...(canRun != null ? { canRun: () => !!canRun } : {}),
+});
+
+const genAbTest = (
+	id: string,
+	canRun?: boolean,
+	expiry?: string,
+	variants?: Variant[],
+): ABTest => ({
+	id,
+	audienceCriteria: 'n/a',
+	audienceOffset: 0,
+	audience: 1,
+	author: 'n/a',
+	showForSensitive: false,
+	canRun: () => {
+		if (canRun != null) return !!canRun;
+		return true;
+	},
+	description: 'n/a',
+	start: '0001-01-01',
+	expiry: expiry || '9999-12-12',
+	successMeasure: 'n/a',
+	variants: variants || [genVariant('control'), genVariant('variant')],
+});
+
+const genRunnableAbTestWhereControlIsRunnable = (
+	id: string,
+	canRun?: boolean,
+): Runnable<ABTest> => {
+	const abTest = genAbTest(id, canRun);
+	return {
+		...abTest,
+		variantToRun: abTest.variants[0],
+	};
+};
+
+const genRunnableAbTestWhereVariantIsRunnable = (
+	id: string,
+	canRun?: boolean,
+): Runnable<ABTest> => {
+	const abTest = genAbTest(id, canRun);
+	return {
+		...abTest,
+		variantToRun: abTest.variants[1],
+	};
+};
+
+describe('A/B utils', () => {
+	describe('runnableTestsToParticipations', () => {
+		it('should set the runnable variant in the participations', () => {
+			expect(
+				runnableTestsToParticipations([
+					genRunnableAbTestWhereControlIsRunnable('a'),
+					genRunnableAbTestWhereControlIsRunnable('b'),
+				]),
+			).toEqual({
+				a: { variant: 'control' },
+				b: { variant: 'control' },
+			});
+
+			expect(
+				runnableTestsToParticipations([
+					genRunnableAbTestWhereControlIsRunnable('c'),
+					genRunnableAbTestWhereVariantIsRunnable('d'),
+				]),
+			).toEqual({
+				c: { variant: 'control' },
+				d: { variant: 'variant' },
+			});
+		});
+	});
+
+	describe('testExclusionsWhoseSwitchExists', () => {
+		it('should filter out non-NOT_IN_TEST variants', () => {
+			expect(
+				testExclusionsWhoseSwitchExists(
+					{
+						SwitchExists: { variant: NOT_IN_TEST },
+						SwitchExists2: { variant: NOT_IN_TEST },
+						SwitchExists3: { variant: 'real' },
+					},
+					{
+						abSwitchExists: false,
+						abSwitchExists2: true,
+					},
+				),
+			).toEqual({
+				SwitchExists: { variant: NOT_IN_TEST },
+				SwitchExists2: { variant: NOT_IN_TEST },
+			});
+		});
+
+		it('should exclude NOT_IN_TEST variants whose switch does not exist', () => {
+			expect(
+				testExclusionsWhoseSwitchExists(
+					{
+						SwitchExists: { variant: NOT_IN_TEST },
+						SwitchExists2: { variant: NOT_IN_TEST },
+						SwitchExists3: { variant: 'real' },
+					},
+					{},
+				),
+			).toEqual({});
+		});
+	});
+
+	describe('testAndParticipationsToVariant', () => {
+		it('should return the NOT_IN_TEST variant if present', () => {
+			const notInTestVariant = genVariant(NOT_IN_TEST);
+			expect(
+				testAndParticipationsToVariant(
+					genAbTest('a', true, '9999-12-12', [
+						genVariant('control'),
+						notInTestVariant,
+					]),
+					{
+						a: { variant: NOT_IN_TEST },
+						b: { variant: 'hey' },
+					},
+				),
+			).toHaveProperty('id', NOT_IN_TEST);
+		});
+
+		it('should return a normal variant if no NOT_IN_TEST variant present', () => {
+			const variant = genVariant('Variant');
+			expect(
+				testAndParticipationsToVariant(
+					genAbTest('b', true, '9999-12-12', [
+						genVariant('control'),
+						variant,
+					]),
+					{
+						a: { variant: 'hey' },
+						b: { variant: 'Variant' },
+					},
+				),
+			).toEqual(variant);
+		});
+	});
+});

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,86 @@
+import { ABTest, Variant, Runnable } from './types';
+
+const NOT_IN_TEST = 'notintest';
+
+const notInTestVariant = {
+	id: NOT_IN_TEST,
+	// eslint-disable-next-line @typescript-eslint/no-empty-function
+	test: () => {},
+};
+
+type Participations = {
+	[testId: string]: {
+		variant: string;
+	};
+};
+
+const toPairs = (obj: {
+	[key: string]: { variant: string };
+}): [string, { variant: string }][] => {
+	const arr = [] as [string, { variant: string }][];
+	for (const [key, value] of Object.entries(obj)) {
+		arr.push([key, value]);
+	}
+	return arr;
+};
+
+const fromPairs = (
+	arr: [string, { variant: string }][],
+): { [key: string]: { variant: string } } => {
+	const obj = {} as { [key: string]: { variant: string } };
+	arr.forEach((item) => {
+		obj[item[0]] = item[1];
+	});
+	return obj;
+};
+
+export const isTestSwitchedOn = (
+	testId: string,
+	switches: { [key: string]: boolean },
+): boolean => switches[testId];
+
+export const runnableTestsToParticipations = (
+	runnableTests: ReadonlyArray<Runnable<ABTest>>,
+): Participations =>
+	runnableTests.reduce(
+		(participations: Participations, { id: testId, variantToRun }) => ({
+			...participations,
+			...{ [testId]: { variant: variantToRun.id } },
+		}),
+		{},
+	);
+
+export const testExclusionsWhoseSwitchExists = (
+	participations: Participations,
+	switches: { [key: string]: boolean },
+): Participations => {
+	const pairs: Array<[string, { variant: string }]> = toPairs(
+		participations,
+	).filter(
+		([testId, { variant: variantId }]) =>
+			variantId === NOT_IN_TEST && switches[`ab${testId}`] !== undefined,
+	);
+	return fromPairs(pairs);
+};
+
+// If the given test has a 'notintest' participation, return the notintest variant.
+// Or else, if the given test has a normal variant participation, return that variant.
+export const testAndParticipationsToVariant = (
+	test: ABTest,
+	participations: Participations,
+): Variant | null | undefined => {
+	const participation = participations[test.id];
+	if (participation) {
+		// We need to return something concrete here to ensure
+		// that a notintest variant actually prevents other variants running.
+		if (participation.variant === NOT_IN_TEST) {
+			return notInTestVariant;
+		}
+
+		return test.variants.find(
+			(variant) => variant.id === participation.variant,
+		);
+	}
+
+	return null;
+};


### PR DESCRIPTION
## What does this change?
This is the first stage in including the utils code in ab-rendering. Here we port the code, more or less as is, into a utils module. With the following changes:

- Types updated
- Make tests run
- Removed use of lodash
- Inlined constants
- Refactored `switches` to be passed in as a prop, not read from window

## Next
Once we have all the code integrated and working, we can build out the tests and look to refactor things, possibly inlining the functions here.