### PR TITLE
Fix build

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-	"name": "ab-tests",
 	"version": "0.0.1",
+	"name": "@guardian/ab-rendering",
 	"repository": "https://github.com/guardian/ab-tests.git",
 	"author": "The Guardian",
 	"license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
 		"dist/**/*"
 	],
 	"source": "src/index.ts",
-	"main": "dist/ab.js",
-	"module": "dist/ab.modern.js",
+	"main": "dist/index.js",
+	"module": "dist/index.modern.js",
 	"jest": {
 		"testEnvironment": "jest-environment-jsdom-sixteen"
 	},

--- a/package.json
+++ b/package.json
@@ -48,6 +48,9 @@
 	},
 	"eslintConfig": {
 		"root": true,
+		"ignorePatterns": [
+			"/dist"
+		],
 		"parser": "@typescript-eslint/parser",
 		"plugins": [
 			"@typescript-eslint"


### PR DESCRIPTION
## What does this change?
- Adds `dist` to ignore config for eslint
- Renames to `@guardian/ab-rendering`
- Uses `index` as the filename in the build config in `package.json`