### PR TITLE
Gtrufitt/is user in variant

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,6 @@ Client-side ab testing framework (broken out from Frontend)
 
 ## API
 
-The AB test libary is split into x modules:
-
--   AB Test Core, for initalisation of the ab test framework
--   AB Test Ophan, for initialisation of Ophan tracking for AB tests
-
 ### Initialise AB Tests
 
 ```ts
@@ -24,8 +19,8 @@ const abTests = intialise(coreConfig, ophanConfig);
 // test being a single AB tests
 // [tests] being an array of ab tests
 abTests.core.runnableTest(test);
-abTests.core.allRunnableTests([tests]);
 abTests.core.firstRunnableTest([tests]);
+abTests.core.isUserInVariant(test, variantId);
 
 // [tests] being an array of *runnable* ab tests
 abTest.ophan.registerCompleteEvents([tests]);
@@ -43,6 +38,7 @@ abTest.ophan.trackABTests([tests]);
 | abTestSwitches      | Record<string, boolean>                              | {'TestOne': true}                | An object containing all of the boolean values of abTestSwitches, in Frontend from page.config.switches.abTests                   |
 | forcedTestVariant   | Optional: { testId: ABTest['id']; variant: Variant } |                                  | In Frontend this might be set by the URL override, but otherwise can be used to force a user into a test and variant at init time |
 | forcedTestException | Optional: ABTest['id']                               |                                  | Can be used to force a user out of a test (in Frontend, again with url override)                                                  |
+| arrayOfTestObjects  | ABTest[]                                             |                                  | Pass all tests definitions into the config                                                                                        |
 
 #### ophanConfig
 

--- a/src/ab-core.ts
+++ b/src/ab-core.ts
@@ -32,7 +32,7 @@ export const initCore = (config: ConfigType): coreAPI => {
 		// console.log({
 		// 	expired,
 		// 	pageIsSensitive,
-		// 	shouldShowForSensitive,
+		// 	testShouldShowForSensitive,
 		// 	isTestOn,
 		// 	canTestBeRun,
 		// 	testCanRun: test.canRun(),
@@ -109,6 +109,7 @@ export const initCore = (config: ConfigType): coreAPI => {
 	) => ReadonlyArray<Runnable<ABTest>> | [];
 	const allRunnableTests: AllRunnableTests = (tests) =>
 		tests.reduce<Runnable<ABTest>[]>((prev, currentValue) => {
+			// console.log({ currentValue, runnable: runnableTest(currentValue) });
 			// in this pr
 			const rt = runnableTest(currentValue); // i will remove these comments
 			return rt ? [...prev, rt] : prev; // so that this api can be reviewed seperate
@@ -123,6 +124,7 @@ export const initCore = (config: ConfigType): coreAPI => {
 	const isUserInVariant: coreAPI['isUserInVariant'] = (test, variantId) =>
 		allRunnableTests(arrayOfTestObjects).some(
 			(runnableTest: ABTest & { variantToRun: Variant }) => {
+				// console.log(runnableTest);
 				return (
 					runnableTest.id === test.id &&
 					runnableTest.variantToRun.id === variantId

--- a/src/ab-core.ts
+++ b/src/ab-core.ts
@@ -10,6 +10,7 @@ export const initCore = (config: ConfigType): coreAPI => {
 		abTestSwitches,
 		forcedTestVariant,
 		forcedTestException,
+		arrayOfTestObjects,
 	} = config;
 	// We only take account of a variant's canRun function if it's defined.
 	// If it's not, assume the variant can be run.
@@ -117,9 +118,20 @@ export const initCore = (config: ConfigType): coreAPI => {
 			.map((test: ABTest) => runnableTest(test)) // I will remove these comments
 			.find((rt: Runnable<ABTest> | null) => rt !== null) || null; // so that this API can be reviewed seperate
 
+	const isUserInVariant: coreAPI['isUserInVariant'] = (test, variantId) =>
+		allRunnableTests(arrayOfTestObjects).some(
+			(runnableTest: ABTest & { variantToRun: Variant }) => {
+				return (
+					runnableTest.id === test.id &&
+					runnableTest.variantToRun.id === variantId
+				);
+			},
+		);
+
 	return {
 		runnableTest,
 		allRunnableTests,
 		firstRunnableTest,
+		isUserInVariant,
 	};
 };

--- a/src/ab-core.ts
+++ b/src/ab-core.ts
@@ -104,8 +104,10 @@ export const initCore = (config: ConfigType): coreAPI => {
 		return null;
 	};
 
-	// please ignore
-	const allRunnableTests: coreAPI['allRunnableTests'] = (tests) =>
+	type AllRunnableTests = (
+		tests: ReadonlyArray<ABTest>,
+	) => ReadonlyArray<Runnable<ABTest>> | [];
+	const allRunnableTests: AllRunnableTests = (tests) =>
 		tests.reduce<Runnable<ABTest>[]>((prev, currentValue) => {
 			// in this pr
 			const rt = runnableTest(currentValue); // i will remove these comments
@@ -130,7 +132,6 @@ export const initCore = (config: ConfigType): coreAPI => {
 
 	return {
 		runnableTest,
-		allRunnableTests,
 		firstRunnableTest,
 		isUserInVariant,
 	};

--- a/src/ab-core.ts
+++ b/src/ab-core.ts
@@ -123,13 +123,9 @@ export const initCore = (config: ConfigType): coreAPI => {
 
 	const isUserInVariant: coreAPI['isUserInVariant'] = (test, variantId) =>
 		allRunnableTests(arrayOfTestObjects).some(
-			(runnableTest: ABTest & { variantToRun: Variant }) => {
-				// console.log(runnableTest);
-				return (
-					runnableTest.id === test.id &&
-					runnableTest.variantToRun.id === variantId
-				);
-			},
+			(runnableTest: ABTest & { variantToRun: Variant }) =>
+				runnableTest.id === test.id &&
+				runnableTest.variantToRun.id === variantId,
 		);
 
 	return {

--- a/src/fixtures/ab-test.ts
+++ b/src/fixtures/ab-test.ts
@@ -41,7 +41,7 @@ export const genAbTest = (genAbConfig: genAbConfig): ABTest => {
 		audience: audience || 1,
 		author: 'n/a',
 		canRun: (): boolean => {
-			if (canRun !== null) return !!canRun;
+			if (canRun !== undefined) return !!canRun;
 			return true;
 		},
 		description: 'n/a',

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,9 +9,6 @@ export type ConfigType = {
 };
 
 export type coreAPI = {
-	allRunnableTests: (
-		tests: ReadonlyArray<ABTest>,
-	) => ReadonlyArray<Runnable<ABTest>> | [];
 	runnableTest: (
 		test: ABTest,
 	) => Runnable<ABTest & { variantToRun: Variant }> | null;

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,16 +5,20 @@ export type ConfigType = {
 	abTestSwitches: Record<string, boolean>;
 	forcedTestVariant?: { testId: ABTest['id']; variant: Variant };
 	forcedTestException?: ABTest['id'];
+	arrayOfTestObjects: ABTest[];
 };
 
 export type coreAPI = {
-	runnableTest: (test: ABTest) => Runnable<ABTest> | null;
 	allRunnableTests: (
 		tests: ReadonlyArray<ABTest>,
 	) => ReadonlyArray<Runnable<ABTest>> | [];
+	runnableTest: (
+		test: ABTest,
+	) => Runnable<ABTest & { variantToRun: Variant }> | null;
 	firstRunnableTest: (
 		tests: ReadonlyArray<ABTest>,
 	) => Runnable<ABTest> | null;
+	isUserInVariant: (test: ABTest, variantId: Variant['id']) => boolean;
 };
 
 export type OphanAPIConfig = {


### PR DESCRIPTION
## What does this change?

Adds `isUserInVariant` to call API, which is functionally identical to `isInVariantSynchronous` but more concisely named.

Removes `allRunnableTests` from public API.

Tests and readme updates.