### PR TITLE
Use testId in place of passing the whole test object

### DIFF
--- a/src/ab-core.test.ts
+++ b/src/ab-core.test.ts
@@ -177,10 +177,10 @@ describe('A/B test core', () => {
 			// The user mvtId is 1234, which puts them into the 'control' bucket
 			// with two variants, as it is an even number
 			expect(
-				abTestLibDefault.isUserInVariant(DummyTest, 'control'),
+				abTestLibDefault.isUserInVariant(DummyTest.id, 'control'),
 			).toBeTruthy();
 			expect(
-				abTestLibDefault.isUserInVariant(DummyTest, 'variant'),
+				abTestLibDefault.isUserInVariant(DummyTest.id, 'variant'),
 			).toBeFalsy();
 		});
 
@@ -194,9 +194,11 @@ describe('A/B test core', () => {
 			});
 			// The user mvtId is 1235
 			// so the user should not in the variant bucket
-			expect(abTestLib.isUserInVariant(DummyTest, 'control')).toBeFalsy();
 			expect(
-				abTestLib.isUserInVariant(DummyTest, 'variant'),
+				abTestLib.isUserInVariant(DummyTest.id, 'control'),
+			).toBeFalsy();
+			expect(
+				abTestLib.isUserInVariant(DummyTest.id, 'variant'),
 			).toBeTruthy();
 		});
 
@@ -212,8 +214,12 @@ describe('A/B test core', () => {
 			});
 			// The user mvtId is 1234, and the test audience is 90-100%
 			// so the user should not be in any variants
-			expect(abTestLib.isUserInVariant(DummyTest, 'control')).toBeFalsy();
-			expect(abTestLib.isUserInVariant(DummyTest, 'variant')).toBeFalsy();
+			expect(
+				abTestLib.isUserInVariant(DummyTest.id, 'control'),
+			).toBeFalsy();
+			expect(
+				abTestLib.isUserInVariant(DummyTest.id, 'variant'),
+			).toBeFalsy();
 		});
 
 		test("Returns false when test can't run", () => {
@@ -225,8 +231,12 @@ describe('A/B test core', () => {
 				...initCoreDefaultConfig,
 				...{ arrayOfTestObjects: [DummyTest] },
 			});
-			expect(abTestLib.isUserInVariant(DummyTest, 'control')).toBeFalsy();
-			expect(abTestLib.isUserInVariant(DummyTest, 'variant')).toBeFalsy();
+			expect(
+				abTestLib.isUserInVariant(DummyTest.id, 'control'),
+			).toBeFalsy();
+			expect(
+				abTestLib.isUserInVariant(DummyTest.id, 'variant'),
+			).toBeFalsy();
 		});
 	});
 });

--- a/src/ab-core.ts
+++ b/src/ab-core.ts
@@ -121,10 +121,10 @@ export const initCore = (config: ConfigType): CoreAPI => {
 			.map((test: ABTest) => runnableTest(test)) // I will remove these comments
 			.find((rt: Runnable<ABTest> | null) => rt !== null) || null; // so that this API can be reviewed seperate
 
-	const isUserInVariant: CoreAPI['isUserInVariant'] = (test, variantId) =>
+	const isUserInVariant: CoreAPI['isUserInVariant'] = (testId, variantId) =>
 		allRunnableTests(arrayOfTestObjects).some(
 			(runnableTest: ABTest & { variantToRun: Variant }) =>
-				runnableTest.id === test.id &&
+				runnableTest.id === testId &&
 				runnableTest.variantToRun.id === variantId,
 		);
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,7 +17,10 @@ export type CoreAPI = {
 	firstRunnableTest: (
 		tests: ReadonlyArray<ABTest>,
 	) => Runnable<ABTest> | null;
-	isUserInVariant: (test: ABTest, variantId: Variant['id']) => boolean;
+	isUserInVariant: (
+		testId: ABTest['id'],
+		variantId?: Variant['id'],
+	) => boolean;
 };
 
 export type OphanAPIConfig = {


### PR DESCRIPTION
## What does this change?
We only ever use the id from the `test` object so here we refactor to only require that in `isUserInVariant()`

```
const isUserInVariant: CoreAPI['isUserInVariant'] = (testId, variantId)
```