### PR TITLE
Default to 'variant'

### DIFF
--- a/src/ab-core.test.ts
+++ b/src/ab-core.test.ts
@@ -177,10 +177,10 @@ describe('A/B test core', () => {
 			// The user mvtId is 1234, which puts them into the 'control' bucket
 			// with two variants, as it is an even number
 			expect(
-				abTestLibDefault.isUserInVariant(DummyTest, 'control'),
+				abTestLibDefault.isUserInVariant(DummyTest.id, 'control'),
 			).toBeTruthy();
 			expect(
-				abTestLibDefault.isUserInVariant(DummyTest, 'variant'),
+				abTestLibDefault.isUserInVariant(DummyTest.id, 'variant'),
 			).toBeFalsy();
 		});
 
@@ -194,9 +194,11 @@ describe('A/B test core', () => {
 			});
 			// The user mvtId is 1235
 			// so the user should not in the variant bucket
-			expect(abTestLib.isUserInVariant(DummyTest, 'control')).toBeFalsy();
 			expect(
-				abTestLib.isUserInVariant(DummyTest, 'variant'),
+				abTestLib.isUserInVariant(DummyTest.id, 'control'),
+			).toBeFalsy();
+			expect(
+				abTestLib.isUserInVariant(DummyTest.id, 'variant'),
 			).toBeTruthy();
 		});
 
@@ -212,8 +214,12 @@ describe('A/B test core', () => {
 			});
 			// The user mvtId is 1234, and the test audience is 90-100%
 			// so the user should not be in any variants
-			expect(abTestLib.isUserInVariant(DummyTest, 'control')).toBeFalsy();
-			expect(abTestLib.isUserInVariant(DummyTest, 'variant')).toBeFalsy();
+			expect(
+				abTestLib.isUserInVariant(DummyTest.id, 'control'),
+			).toBeFalsy();
+			expect(
+				abTestLib.isUserInVariant(DummyTest.id, 'variant'),
+			).toBeFalsy();
 		});
 
 		test("Returns false when test can't run", () => {
@@ -225,8 +231,12 @@ describe('A/B test core', () => {
 				...initCoreDefaultConfig,
 				...{ arrayOfTestObjects: [DummyTest] },
 			});
-			expect(abTestLib.isUserInVariant(DummyTest, 'control')).toBeFalsy();
-			expect(abTestLib.isUserInVariant(DummyTest, 'variant')).toBeFalsy();
+			expect(
+				abTestLib.isUserInVariant(DummyTest.id, 'control'),
+			).toBeFalsy();
+			expect(
+				abTestLib.isUserInVariant(DummyTest.id, 'variant'),
+			).toBeFalsy();
 		});
 	});
 });

--- a/src/ab-core.test.ts
+++ b/src/ab-core.test.ts
@@ -202,6 +202,22 @@ describe('A/B test core', () => {
 			).toBeTruthy();
 		});
 
+		test('Returns correct boolean values when default is used', () => {
+			const DummyTest = genAbTest({
+				id: 'DummyTest',
+			});
+			const abTestLib = initCore({
+				...initCoreDefaultConfig,
+				...{ arrayOfTestObjects: [DummyTest], mvtCookieId: 1235 },
+			});
+			// The user mvtId is 1235
+			// so the user should not in the variant bucket
+			expect(
+				abTestLib.isUserInVariant(DummyTest.id, 'control'),
+			).toBeFalsy();
+			expect(abTestLib.isUserInVariant(DummyTest.id)).toBeTruthy();
+		});
+
 		test('Returns false when user is in no variant', () => {
 			const DummyTest = genAbTest({
 				id: 'DummyTest',

--- a/src/ab-core.ts
+++ b/src/ab-core.ts
@@ -121,10 +121,10 @@ export const initCore = (config: ConfigType): CoreAPI => {
 			.map((test: ABTest) => runnableTest(test)) // I will remove these comments
 			.find((rt: Runnable<ABTest> | null) => rt !== null) || null; // so that this API can be reviewed seperate
 
-	const isUserInVariant: CoreAPI['isUserInVariant'] = (test, variantId) =>
+	const isUserInVariant: CoreAPI['isUserInVariant'] = (testId, variantId) =>
 		allRunnableTests(arrayOfTestObjects).some(
 			(runnableTest: ABTest & { variantToRun: Variant }) =>
-				runnableTest.id === test.id &&
+				runnableTest.id === testId &&
 				runnableTest.variantToRun.id === variantId,
 		);
 

--- a/src/ab-core.ts
+++ b/src/ab-core.ts
@@ -121,7 +121,10 @@ export const initCore = (config: ConfigType): CoreAPI => {
 			.map((test: ABTest) => runnableTest(test)) // I will remove these comments
 			.find((rt: Runnable<ABTest> | null) => rt !== null) || null; // so that this API can be reviewed seperate
 
-	const isUserInVariant: CoreAPI['isUserInVariant'] = (testId, variantId) =>
+	const isUserInVariant: CoreAPI['isUserInVariant'] = (
+		testId,
+		variantId = 'variant',
+	) =>
 		allRunnableTests(arrayOfTestObjects).some(
 			(runnableTest: ABTest & { variantToRun: Variant }) =>
 				runnableTest.id === testId &&

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,7 +17,10 @@ export type CoreAPI = {
 	firstRunnableTest: (
 		tests: ReadonlyArray<ABTest>,
 	) => Runnable<ABTest> | null;
-	isUserInVariant: (test: ABTest, variantId: Variant['id']) => boolean;
+	isUserInVariant: (
+		testId: ABTest['id'],
+		variantId?: Variant['id'],
+	) => boolean;
 };
 
 export type OphanAPIConfig = {


### PR DESCRIPTION
## What does this change?
Defaults the `variantId` prop to 'variant'.

From checking frontend I can see we exclusively use 'variant' as the id for the variant in `isUserInVariant()`. In addition, the name of the function suggests the text variant. So here I'm setting the default to 'variant'.
